### PR TITLE
add offer name length counter and validator

### DIFF
--- a/i18n/pl_PL.csv
+++ b/i18n/pl_PL.csv
@@ -140,3 +140,4 @@
 "Invalid max value format! Allowed format is decimal number","Niepoprawny format maksymalnej wartości! Dozwolony format to liczba dziesiętna"
 "Invalid min value format! Allowed format is decimal number","Niepoprawny format minimalnej wartości! Dozwolony format to liczba dziesiętna"
 "Fill second value","Wpisz drugą wartość"
+"Maximum name length cannot exceed 50 characters, but some characters are counted as longer: &, "", <, >","Maksymalna długość nazwy nie może przekraczać 50 znaków, jednak niektóre znaki są liczone jako dłuższe: &, "", <, >"

--- a/view/adminhtml/ui_component/allegro_offer_form_create.xml
+++ b/view/adminhtml/ui_component/allegro_offer_form_create.xml
@@ -74,9 +74,11 @@
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">input</item>
+                    <item name="component" xsi:type="string">Macopedia_Allegro/js/allegro_offer/form/field/name-length-counter</item>
+                    <item name="elementTmpl" xsi:type="string">Macopedia_Allegro/allegro_offer/form/field/name-length-counter</item>
                     <item name="validation" xsi:type="array">
                         <item name="required-entry" xsi:type="boolean">true</item>
-                        <item name="max_text_length" xsi:type="number">50</item>
+                        <item name="allegro-name-length" xsi:type="boolean">true</item>
                     </item>
                 </item>
             </argument>
@@ -146,9 +148,6 @@
                     <item name="formElement" xsi:type="string">select</item>
                     <item name="label" xsi:type="string" translate="true">Implied warranty</item>
                     <item name="template" xsi:type="string">ui/form/field</item>
-<!--                    <item name="validation" xsi:type="array">-->
-<!--                        <item name="required-entry" xsi:type="boolean">true</item>-->
-<!--                    </item>-->
                 </item>
             </argument>
         </field>
@@ -160,9 +159,6 @@
                     <item name="formElement" xsi:type="string">select</item>
                     <item name="label" xsi:type="string" translate="true">Return policy</item>
                     <item name="template" xsi:type="string">ui/form/field</item>
-<!--                    <item name="validation" xsi:type="array">-->
-<!--                        <item name="required-entry" xsi:type="boolean">true</item>-->
-<!--                    </item>-->
                 </item>
             </argument>
         </field>

--- a/view/adminhtml/ui_component/allegro_offer_form_edit.xml
+++ b/view/adminhtml/ui_component/allegro_offer_form_edit.xml
@@ -76,9 +76,11 @@
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">input</item>
+                    <item name="component" xsi:type="string">Macopedia_Allegro/js/allegro_offer/form/field/name-length-counter</item>
+                    <item name="elementTmpl" xsi:type="string">Macopedia_Allegro/allegro_offer/form/field/name-length-counter</item>
                     <item name="validation" xsi:type="array">
                         <item name="required-entry" xsi:type="boolean">true</item>
-                        <item name="max_text_length" xsi:type="number">50</item>
+                        <item name="allegro-name-length" xsi:type="boolean">true</item>
                     </item>
                 </item>
             </argument>
@@ -148,9 +150,6 @@
                     <item name="formElement" xsi:type="string">select</item>
                     <item name="label" xsi:type="string" translate="true">Implied warranty</item>
                     <item name="template" xsi:type="string">ui/form/field</item>
-<!--                    <item name="validation" xsi:type="array">-->
-<!--                        <item name="required-entry" xsi:type="boolean">true</item>-->
-<!--                    </item>-->
                 </item>
             </argument>
         </field>
@@ -162,9 +161,6 @@
                     <item name="formElement" xsi:type="string">select</item>
                     <item name="label" xsi:type="string" translate="true">Return policy</item>
                     <item name="template" xsi:type="string">ui/form/field</item>
-<!--                    <item name="validation" xsi:type="array">-->
-<!--                        <item name="required-entry" xsi:type="boolean">true</item>-->
-<!--                    </item>-->
                 </item>
             </argument>
         </field>

--- a/view/adminhtml/web/js/allegro_offer/form/field/name-length-counter.js
+++ b/view/adminhtml/web/js/allegro_offer/form/field/name-length-counter.js
@@ -1,0 +1,21 @@
+define([
+    'Magento_Ui/js/form/element/abstract',
+    'Macopedia_Allegro/js/allegro_offer/validation/name-length'
+], function (Input) {
+    return Input.extend({
+        allegroNameLength: function (value) {
+            /**
+             * https://github.com/allegro/allegro-api/issues/919#issuecomment-458847412
+             */
+            var allegroEscapeList = {
+                '&': '&amp;',
+                '"': '&quot;',
+                '<': '&lt;',
+                '>': '&gt;'
+            };
+            return value.replace(/./g, function(c) {
+                return allegroEscapeList.hasOwnProperty(c) ? allegroEscapeList[c] : c
+            }).length
+        }
+    });
+});

--- a/view/adminhtml/web/js/allegro_offer/validation/name-length.js
+++ b/view/adminhtml/web/js/allegro_offer/validation/name-length.js
@@ -1,0 +1,30 @@
+define([
+    'Magento_Ui/js/lib/validation/validator',
+    'jquery',
+    'mage/translate'
+], function (validator, $) {
+    validator.addRule(
+        'allegro-name-length',
+        function (value) {
+            /**
+             * https://github.com/allegro/allegro-api/issues/919#issuecomment-458847412
+             */
+            var allegroEscapeList = {
+                '&': '&amp;',
+                '"': '&quot;',
+                '<': '&lt;',
+                '>': '&gt;'
+            };
+
+            var valueLength = value.replace(/./g, function(c) {
+                return allegroEscapeList.hasOwnProperty(c) ? allegroEscapeList[c] : c
+            }).length;
+
+            if (valueLength > 50) {
+                return false
+            }
+            return true
+        },
+        $.mage.__('Maximum name length cannot exceed 50 characters, but some characters are counted as longer: &, "", <, >')
+    );
+});

--- a/view/adminhtml/web/template/allegro_offer/form/field/name-length-counter.html
+++ b/view/adminhtml/web/template/allegro_offer/form/field/name-length-counter.html
@@ -1,0 +1,26 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div style="display: flex; align-items: center;">
+    <input class="admin__control-text admin__control-text--counter" type="text"
+            data-bind="
+        event: {change: userChanges},
+        value: value,
+        hasFocus: focused,
+        valueUpdate: 'input',
+        attr: {
+            name: inputName,
+            placeholder: placeholder,
+            'aria-describedby': noticeId,
+            id: uid,
+            disabled: disabled,
+            maxlength: 255
+    }"/>
+    <div data-bind="if: validation.max_text_length !== 'undefined'" style="margin-left: 15px;">
+        <span data-bind="text: allegroNameLength(value()) + '/50'"/>
+    </div>
+</div>
+    


### PR DESCRIPTION
I added proper validation to the allegro offer name length ([we have to escape few characters](https://github.com/allegro/allegro-api/issues/919#issuecomment-458847412)) and counter next to name input field.

![image](https://user-images.githubusercontent.com/35779884/67944848-c603e900-fbdd-11e9-9932-16c5f8286cd6.png)
