### PR TITLE
Fix for order importer

### DIFF
--- a/Model/OrderImporter/Status.php
+++ b/Model/OrderImporter/Status.php
@@ -19,6 +19,7 @@ class Status
     const STATE_KEY = 'state';
     const PAID_KEY = 'paid';
     const STATUS_STATE_SEPARATOR = ':';
+    const ALLEGRO_READY_FOR_PROCESSING = "READY_FOR_PROCESSING";
 
     /** @var ScopeConfigInterface */
     private $scopeConfig;
@@ -43,7 +44,7 @@ class Status
         }
 
         $totalPaidValue = $checkoutForm->getSummary()->getTotalToPay()->getAmount();
-        if ($paidAmountValue === $totalPaidValue) {
+        if ($paidAmountValue === $totalPaidValue && $checkoutForm->getStatus() == self::ALLEGRO_READY_FOR_PROCESSING) {
             return $this->arrayResponse(self::PROCESSING_STATUS, Order::STATE_PROCESSING, true);
         }
 


### PR DESCRIPTION
Now: We check if an order is paid on Allegro and we set its status on Magento to processing if it's paid or pending if it's not. When an order has processing status that means that it's over and can't be edited on Allegro, so We upgrade only orders that have status pending.

After: An order will get processing status on Magento only if It's paid and has READY_FOR_PROCESSING status on Allegro because this status means that the order is paid and can't longer be edited. Now We can be sure that orders who haven't got READY_FOR_PROCESSING status on Allegro will be upgraded.