### PR TITLE
installation error allegro api key duplicated

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -59,9 +59,6 @@ class UpgradeData implements UpgradeDataInterface
                 $this->statusResource->assignState(self::PENDING_STATUS, $state, false);
             }
 
-            $this->resource->getConnection()
-                ->insert($this->resource->getTableName('queue'), ['name' => 'allegro.api']);
-
             $attribute = 'allegro_offer_id';
             $eavSetup = $this->createEavSetup($setup);
             $entityTypeId = $eavSetup->getEntityTypeId('catalog_product');


### PR DESCRIPTION
queue entry `allegro.api` already added by [queue_consumer.xml](https://github.com/macopedia/magento2-allegro/blob/master/etc/queue_consumer.xml) so there was a installation error
`Module 'Macopedia_Allegro':
Upgrading data... SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'allegro.api' for key 'QUEUE_NAME', query was: INSERT INTO `queue` (`name`) VALUES (?)
`